### PR TITLE
Use to_yaml filter for metrics

### DIFF
--- a/templates/cloudwatch.yml.j2
+++ b/templates/cloudwatch.yml.j2
@@ -1,4 +1,4 @@
 ---
 region: {{ sansible_prometheus_cloudwatch_exporter.config.region }}
-metrics: 
-{{ sansible_prometheus_cloudwatch_exporter.config.metrics }}
+metrics:
+{{ sansible_prometheus_cloudwatch_exporter.config.metrics | to_yaml }}


### PR DESCRIPTION
I wasn't sure if this should be a patch or an issue, but I was setting this up today and noticed the cloudwatch exporter yaml parsing was crashing on start. This role was spitting out a list of key value pairs in the config file that cloudwatch exporter reads, and it evidently wasn't valid yaml. So adding this filter fixes it for me. If you don't think this is a bug, I can provide more details about my playbook to see where I made a mistake.